### PR TITLE
Supports title tag for WordPress 4.4

### DIFF
--- a/hm-rewrites.php
+++ b/hm-rewrites.php
@@ -269,14 +269,34 @@ class HM_Rewrite_Rule {
 			return $classes;
 		} );
 
-		add_filter( 'wp_title', function( $title, $sep = '' ) use ( $t ) {
+		/**
+		 * Add support for theme support title tag
+		 * @since 4.4.0
+		 */
+		if ( current_theme_supports( 'title-tag' ) ) {
 
-			foreach ( $t->title_callbacks as $callback )
-				$title = call_user_func_array( $callback, array( $title, $sep ) );
+			add_filter( 'pre_get_document_title', function( $title ) use ( $t ) {
 
-			return $title;
+				$sep = apply_filters( 'document_title_separator', '-' );
 
-		}, 10, 2 );
+				foreach ( $t->title_callbacks as $callback )
+					$title = call_user_func_array( $callback, array( $title, $sep ) );
+
+				return $title;
+
+			} );
+
+		} else {
+			add_filter( 'wp_title', function( $title, $sep = '' ) use ( $t ) {
+
+				foreach ( $t->title_callbacks as $callback )
+					$title = call_user_func_array( $callback, array( $title, $sep ) );
+
+				return $title;
+
+			}, 10, 2 );
+
+		}
 
 		add_action( 'admin_bar_menu', function() use ( $t ) {
 			global $wp_admin_bar;


### PR DESCRIPTION
Since 4.4.0 WP allows theme support for title tag so title_callback won't work. This patch fixes it with new filters.